### PR TITLE
fix: mixing vat stops working after using the wrong activation tool

### DIFF
--- a/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
@@ -454,8 +454,8 @@ public class MixingVatBlockEntity extends BlockEntity implements BlockEntityTick
         if(this.activated) return false;
         this.activated = this.getActivationTool() != null && this.getActivationTool().getItem() == stack.getItem();
 
-        // Reset the activation tool.
-        this.activationTool = ItemStack.EMPTY;
+        // Reset the activation tool if recipe is activated
+        if (activated) this.activationTool = ItemStack.EMPTY;
 
         return this.activated;
     }


### PR DESCRIPTION
previously, using any activation tool on a mixing vat would call the activateRecipe function causing the activation tool to be reset, even if the mixing vat didn't activate. This patch ensures the mixing vat must activate to reset the activation tool