### PR TITLE
Book recipe

### DIFF
--- a/src/main/resources/data/growthcraft/recipes/growthcraft_manual.json
+++ b/src/main/resources/data/growthcraft/recipes/growthcraft_manual.json
@@ -8,5 +8,11 @@
       "item": "minecraft:book"
     }
   ],
-  "book": "growthcraft:growthcraft"
+  "book": "growthcraft:growthcraft",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "patchouli"
+    }
+  ]
 }


### PR DESCRIPTION
added a condition to prevent errors in log if patchouli is absent.

note 1: conditions in recipes have changed in both lexforge and neoforge after 1.20.1. this file will need to be changed in later versions.

note 2: salt ore blocks are broken currently (someone is working on datagen). in dev branch, salt is creative-only at the moment.