### PR TITLE
Culturejar

### DIFF
--- a/src/main/java/growthcraft/cellar/block/BrewKettleBlock.java
+++ b/src/main/java/growthcraft/cellar/block/BrewKettleBlock.java
@@ -110,7 +110,7 @@ public class BrewKettleBlock extends BaseEntityBlock {
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         return this.defaultBlockState()
-                .setValue(LIT, BlockStateUtils.isHeated(context.getLevel(), context.getClickedPos()))
+                .setValue(LIT, BlockStateUtils.isHeatedFromBelow(context.getLevel(), context.getClickedPos()))
                 .setValue(HAS_LID, false);
     }
 

--- a/src/main/java/growthcraft/cellar/block/CultureJarBlock.java
+++ b/src/main/java/growthcraft/cellar/block/CultureJarBlock.java
@@ -100,7 +100,7 @@ public class CultureJarBlock extends BaseEntityBlock {
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         return this.defaultBlockState()
                 .setValue(FACING, context.getHorizontalDirection().getOpposite())
-                .setValue(LIT, BlockStateUtils.isHeated(context.getLevel(), context.getClickedPos()));
+                .setValue(LIT, BlockStateUtils.isHeatedFromTwoBlockRange(context.getLevel(), context.getClickedPos()));
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/block/entity/BrewKettleBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/BrewKettleBlockEntity.java
@@ -232,7 +232,7 @@ public class BrewKettleBlockEntity extends BlockEntity implements BlockEntityTic
                     this.itemStackHandler.getStackInSlot(1),
                     this.FLUID_TANK_0.getFluid(),
                     this.hasLid(),
-                    BlockStateUtils.isHeated(this.getLevel(), this.getBlockPos())
+                    BlockStateUtils.isHeatedFromBelow(this.getLevel(), this.getBlockPos())
             )) {
                 if(!this.FLUID_TANK_1.getFluid().isEmpty()) {
                     if(this.FLUID_TANK_1.getFluid().getRawFluid() == recipe.getOutputFluidStack().getFluid()) {
@@ -251,7 +251,7 @@ public class BrewKettleBlockEntity extends BlockEntity implements BlockEntityTic
     }
 
     public boolean isHeated() {
-        boolean heated = BlockStateUtils.isHeated(this.level, this.getBlockPos());
+        boolean heated = BlockStateUtils.isHeatedFromBelow(this.level, this.getBlockPos());
         // Only change the blockstate if it is different.
         if (this.getBlockState().getValue(LIT).booleanValue() != heated) {
             this.level.setBlock(this.getBlockPos(), this.getBlockState().setValue(LIT, heated), Block.UPDATE_ALL);

--- a/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
@@ -118,12 +118,17 @@ public class CultureJarBlockEntity extends BlockEntity implements BlockEntityTic
     @Override
     public void tick(Level level, BlockPos blockPos, BlockState blockState, CultureJarBlockEntity blockEntity) {
 
-        if(!level.isClientSide && this.isHeated()) {
-            // Do nothing, we are just ensuring that the LIT property is accurate.
+        if (level.isClientSide) {
+            return; // do nothing; below code will send client updates.
+        }
+
+        // every two seconds we update heated state based on surrounding blocks.
+        if (level.getGameTime() % 40 == 14) {
+            this.verifyHeatedState();
         }
 
         // The Culture Jar requires a fluid and an item in order to do anything.
-        if(!level.isClientSide && this.getFluidTank(0).getFluidAmount() > 0 && !this.itemStackHandler.getStackInSlot(0).isEmpty()) {
+        if (this.getFluidTank(0).getFluidAmount() > 0 && !this.itemStackHandler.getStackInSlot(0).isEmpty()) {
             // Check for recipe.
             List<CultureJarRecipe> recipes = this.getMatchingRecipes(this.getFluidStackInTank(0), this.itemStackHandler.getStackInSlot(0));
             CultureJarRecipe recipe = recipes.isEmpty() ? null : recipes.get(0);
@@ -152,9 +157,14 @@ public class CultureJarBlockEntity extends BlockEntity implements BlockEntityTic
                     this.tickClock = 0;
                 }
 
-                this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_ALL);
+                // valid action was done and sendBlockUpdated will send slot info and those two data integers to client.
+                // but we won't do it every tick. no need to update a tiny progressbar 20x per second.
+                // we'll do it one per second for now.
+                if (level.getGameTime() % 20 == 17) {
+                    this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_ALL);
+                }
             }
-        } else if(!level.isClientSide && this.getFluidTank(0).getFluidAmount() > 0 && this.itemStackHandler.getStackInSlot(0).isEmpty()) {
+        } else if(this.getFluidTank(0).getFluidAmount() > 0 && this.itemStackHandler.getStackInSlot(0).isEmpty()) {
             // Check for recipe.
             List<CultureJarStarterRecipe> recipes = this.getMatchingRecipes(this.getFluidStackInTank(0));
             CultureJarStarterRecipe recipe = recipes.isEmpty() ? null : recipes.get(0);
@@ -183,10 +193,14 @@ public class CultureJarBlockEntity extends BlockEntity implements BlockEntityTic
                     this.tickClock = 0;
                 }
 
-                this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_ALL);
+                // valid action was done and sendBlockUpdated will send slot info and those two data integers to client.
+                // but we won't do it every tick. no need to update a tiny progressbar 20x per second.
+                // we'll do it one per second for now.
+                if (level.getGameTime() % 20 == 17) {
+                    this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_ALL);
+                }
             }
         }
-
     }
 
     @Nullable
@@ -202,16 +216,21 @@ public class CultureJarBlockEntity extends BlockEntity implements BlockEntityTic
     }
 
     public boolean isHeated() {
-        boolean heated = BlockStateUtils.isHeated(this.level, this.getBlockPos());
-        // Only change the blockstate if it is different.
-        if(this.getBlockState().getValue(LIT).booleanValue() != heated) {
-            this.level.setBlock(this.getBlockPos(), this.getBlockState().setValue(LIT, heated), Block.UPDATE_ALL);
+        if (this.level == null) {
+            return false;
         }
-        return heated;
+        return this.getBlockState().getValue(LIT);
     }
 
-    public boolean isInputTankFull() {
-        return this.getFluidTank(0).getCapacity() == this.getFluidTank(0).getFluidAmount();
+    public void verifyHeatedState() {
+        if (this.level == null) {
+            return;
+        }
+        boolean heated = BlockStateUtils.isHeatedFromTwoBlockRange(this.level, this.getBlockPos());
+        // Only change the blockstate if it is different.
+        if (this.getBlockState().getValue(LIT) != heated) {
+            this.level.setBlock(this.getBlockPos(), this.getBlockState().setValue(LIT, heated), Block.UPDATE_CLIENTS);
+        }
     }
 
     public void setFluidStackInTank(int tankID, FluidStack fluidStack) {

--- a/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
@@ -115,9 +115,16 @@ public class CultureJarBlockEntity extends BlockEntity implements BlockEntityTic
                 : Component.translatable("container.growthcraft_cellar.culture_jar");
     }
 
+    public void dropHeldItems() {
+        // called when the block is destroyed. drops items from item slots.
+        if (this.level != null && !this.itemStackHandler.getStackInSlot(0).isEmpty()) {
+            Block.popResource(this.level, this.getBlockPos(), this.itemStackHandler.getStackInSlot(0));
+            this.itemStackHandler.setStackInSlot(0, ItemStack.EMPTY);
+        }
+    }
+
     @Override
     public void tick(Level level, BlockPos blockPos, BlockState blockState, CultureJarBlockEntity blockEntity) {
-
         if (level.isClientSide) {
             return; // do nothing; below code will send client updates.
         }
@@ -362,6 +369,4 @@ public class CultureJarBlockEntity extends BlockEntity implements BlockEntityTic
         }
         return super.getCapability(cap, side);
     }
-
-
 }

--- a/src/main/java/growthcraft/cellar/block/entity/RoasterBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/RoasterBlockEntity.java
@@ -141,7 +141,7 @@ public class RoasterBlockEntity extends BlockEntity implements BlockEntityTicker
     }
 
     public boolean isHeated() {
-        boolean heated = BlockStateUtils.isHeated(this.level, this.getBlockPos());
+        boolean heated = BlockStateUtils.isHeatedFromBelow(this.level, this.getBlockPos());
         // Only change the blockstate if it is different.
         if (Boolean.TRUE.equals(this.getBlockState().getValue(LIT)) != heated) {
             if (level != null)

--- a/src/main/java/growthcraft/lib/utils/BlockStateUtils.java
+++ b/src/main/java/growthcraft/lib/utils/BlockStateUtils.java
@@ -79,8 +79,27 @@ public class BlockStateUtils {
         return blockStateMap;
     }
 
-    public static boolean isHeated(BlockGetter blockGetter, BlockPos blockPos) {
-        Map<String, BlockState> blockMap = BlockStateUtils.getSurroundingBlockState(blockGetter, blockPos);
-        return blockMap.get("below").is(GrowthcraftTags.Blocks.HEATSOURCES);
+    public static boolean isHeatedFromBelow(BlockGetter blockGetter, BlockPos blockPos) {
+        return blockGetter.getBlockState(blockPos.below()).is(GrowthcraftTags.Blocks.HEATSOURCES);
+    }
+
+    public static boolean isHeatedFromTwoBlockRange(BlockGetter blockGetter, BlockPos blockPos) {
+        BlockPos.MutableBlockPos positionToCheck = new BlockPos.MutableBlockPos();
+        for (int dx = -2; dx <= 2; dx++) {
+            for (int dy = -2; dy <= 2; dy++) {
+                for (int dz = -2; dz <= 2; dz++) {
+                    // loops give us a diameter of 2 cube...
+                    if (dx * dx + dy * dy + dz * dz < 7) {
+                        // we consider edges to be too far.
+                        // so: two blocks away and maybe one to the side
+                        positionToCheck.set(blockPos.getX() + dx, blockPos.getY() + dy, blockPos.getZ() + dz);
+                        if (blockGetter.getBlockState(positionToCheck).is(GrowthcraftTags.Blocks.HEATSOURCES)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/growthcraft/milk/block/MixingVatBlock.java
+++ b/src/main/java/growthcraft/milk/block/MixingVatBlock.java
@@ -91,7 +91,7 @@ public class MixingVatBlock extends BaseEntityBlock {
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         return this.defaultBlockState()
-                .setValue(LIT, BlockStateUtils.isHeated(context.getLevel(), context.getClickedPos()));
+                .setValue(LIT, BlockStateUtils.isHeatedFromBelow(context.getLevel(), context.getClickedPos()));
     }
 
     @Override

--- a/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
@@ -539,7 +539,7 @@ public class MixingVatBlockEntity extends BlockEntity implements BlockEntityTick
     }
 
     public boolean isHeated() {
-        boolean heated = BlockStateUtils.isHeated(this.level, this.getBlockPos());
+        boolean heated = BlockStateUtils.isHeatedFromBelow(this.level, this.getBlockPos());
         // Only change the blockstate if it is different.
         if(this.getBlockState().getValue(LIT).booleanValue() != heated) {
             this.level.setBlock(this.getBlockPos(), this.getBlockState().setValue(LIT, heated), Block.UPDATE_ALL);


### PR DESCRIPTION
implementation of #84

1) when broken, culture jar will pop out yeast or whatever item was inside (previously it was lost). juice will be lost as before. 
2) culture jars need a solid or somewhat solid block below them now. smallest block what works is a stone wall; anything with a solid top should work as before.
3) culture jars now need heat to be in radius of 2 blocks (more like 2.5, technically), not necessarily below. as a result we can keep them on tables and have a few jars share a heat block. or we can even hide the unsightly heat block. technical details: method BlockStateUtils.isHeated was removed and replaced with two methods isHeatedFromBelow and isHeatedFromTwoBlockRange. Kettle, Roaster and Mixing Vat use the former, jar uses the latter.
4) checking for heat optimized.
5) sending updates to the client optimized.