### PR TITLE
Open GUIs for cellar processors without requiring Sneak

### DIFF
--- a/src/main/java/growthcraft/cellar/block/FermentationBarrelBlock.java
+++ b/src/main/java/growthcraft/cellar/block/FermentationBarrelBlock.java
@@ -162,7 +162,7 @@ public class FermentationBarrelBlock extends BaseEntityBlock implements SimpleWa
                             || player.getItemInHand(interactionHand).getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM).isPresent()
             ) {
                 return InteractionResult.SUCCESS;
-            } else if(player.isCrouching()) {
+            } else {
                 try {
                     // Play sound
                     level.playSound(player, blockPos, SoundEvents.BARREL_OPEN, SoundSource.BLOCKS, 1.0F, 1.0F);

--- a/src/main/java/growthcraft/cellar/block/FruitPressBlock.java
+++ b/src/main/java/growthcraft/cellar/block/FruitPressBlock.java
@@ -138,7 +138,7 @@ public class FruitPressBlock extends BaseEntityBlock {
 
             if (FluidUtil.interactWithFluidHandler(player, interactionHand, level, blockPos, hitResult.getDirection()) || player.getItemInHand(interactionHand).getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM).isPresent()) {
                 return InteractionResult.SUCCESS;
-            } else if (player.isCrouching() && !level.getBlockState(blockPos.above()).getValue(PRESSED)) {
+            } else if (!level.getBlockState(blockPos.above()).getValue(PRESSED)) {
                 try {
                     // Play sound
                     level.playSound(player, blockPos, SoundEvents.BARREL_OPEN, SoundSource.BLOCKS, 1.0F, 1.0F);

--- a/src/main/java/growthcraft/cellar/block/FruitPressPistonBlock.java
+++ b/src/main/java/growthcraft/cellar/block/FruitPressPistonBlock.java
@@ -142,7 +142,7 @@ public class FruitPressPistonBlock  extends Block {
         if(!level.isClientSide && player.getItemInHand(interactionHand).getItem() == Items.LEVER) {
             level.setBlock(blockPos.above(), Blocks.LEVER.getStateDefinition().any().setValue(FACING, blockState.getValue(FACING)), Block.UPDATE_ALL_IMMEDIATE);
             player.getItemInHand(interactionHand).shrink(1);
-        } else if (!level.isClientSide && player.isCrouching() && !blockState.getValue(PRESSED)) {
+        } else if (!level.isClientSide && !blockState.getValue(PRESSED)) {
             try {
                 // Play sound
                 level.playSound(player, blockPos, SoundEvents.BARREL_OPEN, SoundSource.BLOCKS, 1.0F, 1.0F);


### PR DESCRIPTION
Provides normal GUI interaction (opening on right-click without sneak) for:
- Culture Jar
- Fermentation Barrel
- Fruit Press (and accompanying piston block)

Preserves fluid handling interactions (including special case for Vanilla Milk going into Culture Jar).

Used c38c74a that did the same for the Brew Kettle as reference.