### PR TITLE
Added bottles to various chests in world

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,10 @@ dependencies {
     runtimeOnly fg.deobf("curse.maven:patchouli-${curseforge_patchouli}")
     runtimeOnly fg.deobf("curse.maven:appleskin-${curseforge_appleskin}")
     runtimeOnly fg.deobf("curse.maven:mekanism-${curseforge_mekanism}")
-    runtimeOnly fg.deobf("curse.maven:mekanism-${curseforge_farmers_delight}")
+    runtimeOnly fg.deobf("curse.maven:farmers-delight-${curseforge_farmers_delight}")
+
+    // Nice thing that shows the nbt in scrollable manner
+    runtimeOnly fg.deobf("curse.maven:item-nbt-viewer-514135:4578522")
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
+++ b/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
@@ -1,10 +1,12 @@
 package growthcraft.cellar;
 
+import com.mojang.serialization.Codec;
 import growthcraft.cellar.init.*;
 import growthcraft.cellar.init.client.GrowthcraftCellarBlockEntityRenderers;
 import growthcraft.cellar.init.client.GrowthcraftCellarBlockRenderers;
 import growthcraft.cellar.init.config.GrowthcraftCellarConfig;
 import growthcraft.cellar.lib.networking.GrowthcraftCellarMessages;
+import growthcraft.cellar.other.LootModifierForBottlesInChests;
 import growthcraft.cellar.screen.*;
 import growthcraft.cellar.shared.Reference;
 import growthcraft.core.init.GrowthcraftCreativeModeTabs;
@@ -12,6 +14,7 @@ import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -20,6 +23,9 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -28,6 +34,8 @@ import org.apache.logging.log4j.Logger;
 @Mod.EventBusSubscriber(modid = Reference.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class GrowthcraftCellar {
     public static final Logger LOGGER = LogManager.getLogger(Reference.MODID);
+    private static final DeferredRegister<Codec<? extends IGlobalLootModifier>> LOOT_MODIFIERS = DeferredRegister.create(ForgeRegistries.Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, Reference.MODID);
+    private static final RegistryObject<Codec<? extends IGlobalLootModifier>> GLMSerializer1 = LOOT_MODIFIERS.register("bottles_in_loot_chests", LootModifierForBottlesInChests.CODEC);
 
     public GrowthcraftCellar() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
@@ -46,6 +54,7 @@ public class GrowthcraftCellar {
         GrowthcraftCellarFluids.FLUID_TYPES.register(modEventBus);
         GrowthcraftCellarFluids.FLUIDS.register(modEventBus);
         GrowthcraftCellarMenus.MENUS.register(modEventBus);
+        LOOT_MODIFIERS.register(modEventBus);
 
         GrowthcraftCellarRecipes.register(modEventBus);
 

--- a/src/main/java/growthcraft/cellar/init/config/GrowthcraftCellarConfig.java
+++ b/src/main/java/growthcraft/cellar/init/config/GrowthcraftCellarConfig.java
@@ -25,10 +25,19 @@ public class GrowthcraftCellarConfig {
     private static ForgeConfigSpec.IntValue hops_min_fruit;
     private static ForgeConfigSpec.IntValue hops_max_fruit;
 
+    private static ForgeConfigSpec.IntValue loot_chance_pillager_outpost;
+    private static ForgeConfigSpec.IntValue loot_chance_ocean_ruin;
+    private static ForgeConfigSpec.IntValue loot_chance_shipwreck;
+    private static ForgeConfigSpec.IntValue loot_chance_village;
+    private static ForgeConfigSpec.IntValue loot_chance_beach_treasure;
+    private static ForgeConfigSpec.IntValue loot_chance_dark_forest_mansion;
+    private static ForgeConfigSpec.IntValue loot_chance_stronghold;
+
     static {
         initBrewKettleConfig(SERVER_BUILDER);
         initGrapeVineConfig(SERVER_BUILDER);
         initHopsCropConfig(SERVER_BUILDER);
+        initLootConfig(SERVER_BUILDER);
 
         SERVER = SERVER_BUILDER.build();
     }
@@ -76,6 +85,32 @@ public class GrowthcraftCellarConfig {
                 .defineInRange("hops_crop.max_fruit_yield", 3, 1, 100);
     }
 
+    public static void initLootConfig(ForgeConfigSpec.Builder server) {
+        server.push("bottles_in_loot_chest");  // spaces would be fine here but i'll follow the existing style.
+        loot_chance_pillager_outpost = server
+                .comment("Percentage chance you'll find a few bottles of mead in pillager tower chest. Number here seems high but that bum place has only one chest and this fits the theme.")
+                .defineInRange("loot_chance_pillager_outpost", 90, 0, 100);   // spaces would be fine here but i'll follow the existing style.
+        loot_chance_ocean_ruin = server
+                .comment("Percentage chance you'll find a few bottles of wine in underwater ruin chest. Default of 10% is not low because ruins will have half a dozen chests.")
+                .defineInRange("loot_chance_underwater_ruins", 10, 0, 100);
+        loot_chance_shipwreck = server
+                .comment("Percentage chance you'll find a few bottles of ale in shipwreck chest.")
+                .defineInRange("loot_chance_shipwreck", 60, 0, 100);
+        loot_chance_village = server
+                .comment("Percentage chance you'll find a few bottles of wine in villager home chest.")
+                .defineInRange("loot_chance_village", 0, 0, 100);   // default is 0 - disabled for now.
+        loot_chance_beach_treasure = server
+                .comment("Percentage chance you'll find a few bottles of wine in buried beach chest.")
+                .defineInRange("loot_chance_beach_treasure", 0, 0, 100);   // default is 0 - disabled for now.
+        loot_chance_dark_forest_mansion = server
+                .comment("Percentage chance you'll find a few bottles of lager in woodland mansion chest.")
+                .defineInRange("loot_chance_dark_forest_mansion", 15, 0, 100);
+        loot_chance_stronghold = server
+                .comment("Percentage chance you'll find a few bottles of wine in stronghold chest.")
+                .defineInRange("loot_chance_stronghold", 0, 0, 100);   // default is 0 - disabled for now. some absorption won't be too bad.
+        server.pop();
+    }
+
     public static int getBrewKettleLitLightLevel() {
         return brew_kettle_lit_light_level.get();
     }
@@ -99,4 +134,14 @@ public class GrowthcraftCellarConfig {
     public static int getHopsCropMaxFruitYield() {
         return hops_max_fruit.get();
     }
+
+    // bug, may2024: all the above 6 values are unused
+
+    public static int getLootChancePillagerTower() { return loot_chance_pillager_outpost.get(); }
+    public static int getLootChanceOceanRuin()     { return loot_chance_ocean_ruin.get(); }
+    public static int getLootChanceShipwreck()     { return loot_chance_shipwreck.get(); }
+    public static int getLootChanceVillagerHome()  { return loot_chance_village.get(); }
+    public static int getLootChanceBeachTreasure() { return loot_chance_beach_treasure.get(); }
+    public static int getLootChanceMansion()       { return loot_chance_dark_forest_mansion.get(); }
+    public static int getLootChanceStronghold()    { return loot_chance_stronghold.get(); }
 }

--- a/src/main/java/growthcraft/cellar/other/LootModifierForBottlesInChests.java
+++ b/src/main/java/growthcraft/cellar/other/LootModifierForBottlesInChests.java
@@ -1,0 +1,173 @@
+package growthcraft.cellar.other;
+
+import com.google.common.base.Suppliers;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import growthcraft.cellar.init.GrowthcraftCellarItems;
+import growthcraft.cellar.init.config.GrowthcraftCellarConfig;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.alchemy.PotionUtils;
+import net.minecraft.world.level.storage.loot.BuiltInLootTables;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraftforge.common.loot.IGlobalLootModifier;
+import net.minecraftforge.common.loot.LootModifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Supplier;
+
+// puts some wine and ale into loot chests in world to tell players that there are drinks to be brewed.
+public class LootModifierForBottlesInChests extends LootModifier
+{
+    @Override
+    protected @NotNull ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context)
+    {
+        // step 0: this assertion will crash the game in 1.20.6 and later
+        // this will force someone to update comparisons below (PILLAGER_OUTPOST will become a ResourceKey).
+        // without this, in 1.20.6,  lootTableId.equals(some table)  would just quietly always return false.
+        // that took some of us many hours to figure out
+        assert BuiltInLootTables.PILLAGER_OUTPOST.getClass().getSimpleName().equals("ResourceLocation");
+
+        // step 1: roll the dice
+        int chance = 0;
+        ResourceLocation lootTableId = context.getQueriedLootTableId();
+        if (lootTableId.equals(BuiltInLootTables.PILLAGER_OUTPOST))
+        {
+            chance = GrowthcraftCellarConfig.getLootChancePillagerTower();
+        }
+        else if (lootTableId.equals(BuiltInLootTables.UNDERWATER_RUIN_SMALL) || lootTableId.equals(BuiltInLootTables.UNDERWATER_RUIN_BIG))
+        {
+            chance = GrowthcraftCellarConfig.getLootChanceOceanRuin();
+        }
+        else if (lootTableId.equals(BuiltInLootTables.SHIPWRECK_SUPPLY) || lootTableId.equals(BuiltInLootTables.SHIPWRECK_MAP))
+        {
+            chance = GrowthcraftCellarConfig.getLootChanceShipwreck();
+        }
+        else if (lootTableId.getPath().startsWith("chests/village/"))
+        {
+            chance = GrowthcraftCellarConfig.getLootChanceVillagerHome();
+        }
+        else if (lootTableId.equals(BuiltInLootTables.BURIED_TREASURE))
+        {
+            chance = GrowthcraftCellarConfig.getLootChanceBeachTreasure();
+        }
+        else if (lootTableId.equals(BuiltInLootTables.WOODLAND_MANSION))
+        {
+            chance = GrowthcraftCellarConfig.getLootChanceMansion();
+        }
+        else if (lootTableId.equals(BuiltInLootTables.STRONGHOLD_CORRIDOR) || lootTableId.equals(BuiltInLootTables.STRONGHOLD_CROSSING))
+        {
+            chance = GrowthcraftCellarConfig.getLootChanceStronghold();
+        }
+        if (!(context.getRandom().nextInt(100) < chance))
+        {
+            return generatedLoot; // random chance failed, pack it in. chance is 0 for the majority of cases anyway.
+        }
+
+        // step 2: decide on loot item. if there are multiple bottles in a chest (no reason why not), we want them of the same type so that they don't take more than 1 inventory slot.
+        // yes we're repeating branches from above. above, there was a 99% chance the chance would be 0, and we didn't want to do any more logic other than rolling.
+        CompoundTag tag = new CompoundTag();
+        int min = 1, max = 2;
+        MobEffectInstance effect1 = null, effect2 = null;
+        String nameKey = "asd";
+        if (lootTableId.equals(BuiltInLootTables.PILLAGER_OUTPOST))
+        {
+            min = 6; max = 14;
+            effect1 = new MobEffectInstance(MobEffects.HEALTH_BOOST, 3600, 1, true, false);
+            nameKey = "fluid_type.growthcraft_apiary.honey_mead_fluid";
+        }
+        else if (lootTableId.equals(BuiltInLootTables.UNDERWATER_RUIN_SMALL) || lootTableId.equals(BuiltInLootTables.UNDERWATER_RUIN_BIG))
+        {
+            min = 1; max = 4;
+            effect1 = new MobEffectInstance(MobEffects.SATURATION, 1200, 1, true, false);
+            effect2 = new MobEffectInstance(MobEffects.DOLPHINS_GRACE, 1200, 0, true, false);
+            nameKey = "fluid_type.growthcraft_cellar.white_grape_wine_fluid";
+        }
+        else if (lootTableId.equals(BuiltInLootTables.SHIPWRECK_SUPPLY) || lootTableId.equals(BuiltInLootTables.SHIPWRECK_MAP))
+        {
+            min = 4; max = 8;
+            effect1 = new MobEffectInstance(MobEffects.LUCK, 6000, 1, true, false);
+            nameKey = "fluid_type.growthcraft_cellar.old_port_ale_fluid";
+        }
+        else if (lootTableId.getPath().startsWith("chests/village/"))
+        {
+            min = 1; max = 3;
+            effect1 = new MobEffectInstance(MobEffects.SATURATION, 1200, 1, true, false);
+            nameKey = "fluid_type.growthcraft_cellar.white_grape_wine_fluid";
+        }
+        else if (lootTableId.equals(BuiltInLootTables.BURIED_TREASURE))
+        {
+            min = 2; max = 4;
+            effect1 = new MobEffectInstance(MobEffects.ABSORPTION, 2400, 1, true, false); // recipe's 1min is way too short
+            nameKey = "fluid_type.growthcraft_cellar.purple_grape_wine_fluid";
+        }
+        else if (lootTableId.equals(BuiltInLootTables.WOODLAND_MANSION))
+        {
+            min = 4; max = 8;
+            effect1 = new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 3600, 2, true, false);
+            nameKey = "fluid_type.growthcraft_cellar.copper_lager_fluid";
+        }
+        else if (lootTableId.equals(BuiltInLootTables.STRONGHOLD_CORRIDOR) || lootTableId.equals(BuiltInLootTables.STRONGHOLD_CROSSING))
+        {
+            min = 2; max = 10;
+            effect1 = new MobEffectInstance(MobEffects.ABSORPTION, 2400, 1, true, false); // recipe's 1min is way too short
+            nameKey = "fluid_type.growthcraft_cellar.purple_grape_wine_fluid";
+        }
+
+        // step 3: make a stack of bottles
+        ItemStack bottles = GrowthcraftCellarItems.POTION_WINE.get().getDefaultInstance();
+        bottles.setCount(context.getRandom().nextIntBetweenInclusive(min, max));
+        if (effect1 != null) {
+            if (effect2 == null) {
+                PotionUtils.setCustomEffects(bottles, ObjectArrayList.of(effect1));
+            }
+            else {
+                PotionUtils.setCustomEffects(bottles, ObjectArrayList.of(effect1, effect2));
+            }
+        }
+        bottles.setHoverName(Component.translatable(nameKey));
+
+        // step 3b: add a stack of bottles
+        if (generatedLoot.size() < 27)
+        {
+            generatedLoot.add(bottles);
+        }
+        else
+        {
+            // step 3c: if full, pick an empty slot and add a stack of bottles.
+            for (int i = generatedLoot.size() - 1; i >= 0; i--)
+            {
+                if (generatedLoot.get(i).isEmpty()) // we could replace some useless items (wheat, etc) but that might be too fancy for growthcraft.
+                {
+                    generatedLoot.set(i, bottles);
+                    break;
+                }
+            }
+        }
+
+        return generatedLoot;
+    }
+
+    //////  nothing useful below this line ///////////////////////////////////////
+
+    protected LootModifierForBottlesInChests(LootItemCondition[] conditionsIn)
+    {
+        super(conditionsIn);
+    }
+
+    @Override
+    public Codec<? extends IGlobalLootModifier> codec()
+    {
+        return null;
+    }
+    public static final Supplier<Codec<LootModifierForBottlesInChests>> CODEC = Suppliers.memoize(() ->
+            RecordCodecBuilder.create(inst -> codecStart(inst)
+                    // no fields. if there were, we'd call .and() here
+                    .apply(inst, LootModifierForBottlesInChests::new)));
+}

--- a/src/main/resources/data/forge/loot_modifiers/global_loot_modifiers.json
+++ b/src/main/resources/data/forge/loot_modifiers/global_loot_modifiers.json
@@ -11,7 +11,7 @@
     "growthcraft_cellar:yeast_ethereal_from_chorus_flower",
     "growthcraft_cellar:yeast_lager_from_snow",
     "growthcraft_milk:thistle_seeds_from_grass",
-    "growthcraft_rice:rice_from_grass"
-
+    "growthcraft_rice:rice_from_grass",
+    "growthcraft_cellar:bottles_in_loot_chests"
   ]
 }

--- a/src/main/resources/data/growthcraft_cellar/loot_modifiers/bottles_in_loot_chests.json
+++ b/src/main/resources/data/growthcraft_cellar/loot_modifiers/bottles_in_loot_chests.json
@@ -1,0 +1,4 @@
+{
+  "type": "growthcraft_cellar:bottles_in_loot_chests",
+  "conditions": [ ]
+}


### PR DESCRIPTION
we need to remind players to make that first barrel...


to test try
`/setblock ~ ~ ~1 minecraft:chest{ LootTable: 'minecraft:chests/pillager_outpost' }`
or something like that. that one has a high chance by default.
others may seem not to work because of low odds.