### PR TITLE
barrel performance and yeast count bug

### DIFF
--- a/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
@@ -72,20 +72,17 @@ public class FermentationBarrelRecipe implements Recipe<SimpleContainer> {
     public boolean matches(ItemStack matchInputItemStack, FluidStack matchInputFluidStack) {
 
         boolean inputFluidMatches = this.inputFluidStack.getFluid() == matchInputFluidStack.getFluid()
-                && this.inputFluidStack.getAmount() <= matchInputFluidStack.getAmount()
+                && matchInputFluidStack.getAmount() >= this.inputFluidStack.getAmount()
                 && this.getOutputMultiplier(matchInputFluidStack) > 0;
 
         boolean inputItemMatches = this.inputItemStack.getItem() == matchInputItemStack.getItem()
-                && this.inputItemStack.getCount() <= matchInputItemStack.getCount() * this.getOutputMultiplier(matchInputFluidStack);
+                && matchInputItemStack.getCount() >= this.inputItemStack.getCount() * this.getOutputMultiplier(matchInputFluidStack);
 
         return inputItemMatches && inputFluidMatches;
     }
 
     /**
      * Determines the output multiplier based on the amount of fluid in the tank.
-     *
-     * @param fluidStackInTank
-     * @return
      */
     public int getOutputMultiplier(FluidStack fluidStackInTank) {
         return fluidStackInTank.getAmount() % this.inputFluidStack.getAmount() == 0
@@ -94,24 +91,23 @@ public class FermentationBarrelRecipe implements Recipe<SimpleContainer> {
     }
 
     /**
-     * Determine if a FluidStack matches this recipe output.
-     *
-     * @param fluidStack
-     * @return
+     * Determine if a FluidStack matches this recipe's output.
      */
-    public boolean matches(FluidStack fluidStack) {
+    public boolean matchesOutput(FluidStack fluidStack) {
         return this.outputFluidStack.getFluid() == fluidStack.getFluid();
+    }
+
+    /**
+     * Determine if a FluidStack matches this recipe's input.
+     */
+    public boolean matchesInput(FluidStack fluidStack) {
+        return this.inputFluidStack.getFluid() == fluidStack.getFluid();
     }
 
     /**
      * Determine id an ItemStack and two FluidStacks match this recipe.
      *
      * @deprecated Method not specific enough, use {@link #matches(ItemStack, FluidStack)} instead.
-     *
-     * @param inputItemStack
-     * @param inputFluidStack
-     * @param outputFluidStack
-     * @return
      */
     @Deprecated(since = "8.1.0", forRemoval = true)
     public boolean matches(ItemStack inputItemStack, FluidStack inputFluidStack, FluidStack outputFluidStack) {

--- a/src/main/java/growthcraft/cellar/screen/FermentationBarrelScreen.java
+++ b/src/main/java/growthcraft/cellar/screen/FermentationBarrelScreen.java
@@ -10,8 +10,10 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,6 +24,8 @@ import java.util.Optional;
 public class FermentationBarrelScreen extends AbstractContainerScreen<FermentationBarrelMenu> {
 
     private static final ResourceLocation TEXTURE = TextureHelper.getTextureGui(Reference.MODID, Reference.UnlocalizedName.FERMENT_BARREL);
+    private static final List<Component> YEAST_WARNING = List.of(Component.translatable("growthcraft_cellar.tooltip.fermentation.yeast_warning").withStyle(Style.EMPTY.withColor(0xd5bb88)));
+    private static final List<Component> YEAST_ERROR = List.of(Component.translatable("growthcraft_cellar.tooltip.fermentation.yeast_error").withStyle(Style.EMPTY.withColor(0xd68a71)));
 
     private FluidTankRenderer fluidTankRenderer0;
 
@@ -87,12 +91,11 @@ public class FermentationBarrelScreen extends AbstractContainerScreen<Fermentati
     }
 
     private void renderProgressToolTip(GuiGraphics poseStack, int mouseX, int mouseY, int x, int y) {
-        List<Component> tooltip = new ArrayList<>();
-
-        MutableComponent progressString = Component.translatable(Reference.MODID.concat(".tooltip.fermentation.progress"), menu.getPercentProgress());
-        tooltip.add(progressString);
-
         if (isMouseAboveArea(mouseX, mouseY, x + 48, y + 18, 20, 30, 20, 30)) {
+            List<Component> tooltip = new ArrayList<>();
+            MutableComponent progressString = Component.translatable(Reference.MODID.concat(".tooltip.fermentation.progress"), menu.getPercentProgress());
+            tooltip.add(progressString);
+
             poseStack.renderTooltip(
                     this.font,
                     tooltip,
@@ -112,6 +115,27 @@ public class FermentationBarrelScreen extends AbstractContainerScreen<Fermentati
                     mouseX - x,
                     mouseY - y
             );
+        }
+    }
+
+    @Override     // yeast slot tooltip
+    protected void renderTooltip(GuiGraphics graphics, int mouseX, int mouseY) {
+        if (this.menu.getCarried().isEmpty() && this.hoveredSlot != null && this.hoveredSlot.hasItem()) {
+            if (this.hoveredSlot.container.getContainerSize() <= 3 && this.hoveredSlot.getSlotIndex() == 0) {
+                if (menu.hasYeastWarning()) {
+                    ItemStack itemstack = this.hoveredSlot.getItem();
+                    graphics.renderTooltip(this.font, YEAST_WARNING, itemstack.getTooltipImage(), ItemStack.EMPTY, mouseX, mouseY);
+                }
+                else if (menu.hasYeastError()) {
+                    graphics.renderTooltip(this.font, YEAST_ERROR, Optional.empty(), ItemStack.EMPTY, mouseX, mouseY);
+                }
+                else {
+                    super.renderTooltip(graphics, mouseX, mouseY);
+                }
+            }
+            else {
+                super.renderTooltip(graphics, mouseX, mouseY);
+            }
         }
     }
 

--- a/src/main/java/growthcraft/cellar/screen/container/FermentationBarrelMenu.java
+++ b/src/main/java/growthcraft/cellar/screen/container/FermentationBarrelMenu.java
@@ -158,4 +158,12 @@ public class FermentationBarrelMenu extends AbstractContainerMenu {
     public int getPercentProgress() {
         return this.blockEntity.getPercentProgress();
     }
+
+    public boolean hasYeastWarning() {
+        return this.blockEntity.hasYeastWarning();
+    }
+
+    public boolean hasYeastError() {
+        return this.blockEntity.hasYeastError();
+    }
 }

--- a/src/main/resources/assets/growthcraft_cellar/lang/en_us.json
+++ b/src/main/resources/assets/growthcraft_cellar/lang/en_us.json
@@ -117,6 +117,8 @@
   "item.growthcraft_cellar.yeast_lager_ethereal": "Lager Yeast (Ethereal)",
   "growthcraft_cellar.tooltip.roaster.progress": "Roast Level %s (%d%%)",
   "growthcraft_cellar.tooltip.fermentation.progress": "Fermenting %s%%",
+  "growthcraft_cellar.tooltip.fermentation.yeast_warning": "Insufficient yeast.",
+  "growthcraft_cellar.tooltip.fermentation.yeast_error": "Not a valid yeast for this fluid.",
   "jei.growthcraft_cellar.category.culture_jar": "Culture Jar (Culturing)",
   "jei.growthcraft_cellar.category.culture_jar_starter": "Culture Jar (Starters)",
   "jei.growthcraft_cellar.category.fermentation_barrel": "Fermenting",

--- a/src/main/resources/assets/growthcraft_cellar/lang/ru_ru.json
+++ b/src/main/resources/assets/growthcraft_cellar/lang/ru_ru.json
@@ -114,5 +114,9 @@
   "item.growthcraft_cellar.yeast_brewers_ethereal": "Эфирные пивные дрожжи",
   "item.growthcraft_cellar.yeast_ethereal": "Эфирные дрожжи",
   "item.growthcraft_cellar.yeast_lager": "Лагерные дрожжи",
-  "item.growthcraft_cellar.yeast_lager_ethereal": "Эфирные лагерные дрожжи"
+  "item.growthcraft_cellar.yeast_lager_ethereal": "Эфирные лагерные дрожжи",
+  "growthcraft_cellar.tooltip.roaster.progress": "Roast Level %s (%d%%)",
+  "growthcraft_cellar.tooltip.fermentation.progress": "Fermenting %s%%",
+  "growthcraft_cellar.tooltip.fermentation.yeast_warning": "Insufficient yeast.",
+  "growthcraft_cellar.tooltip.fermentation.yeast_error": "Not a valid yeast for this fluid."
 }


### PR DESCRIPTION
barrel's tick handling is a lot more efficient in two areas: recipe querying and client notifying. as a price, progress bar updates 2x per second, but even 1x would be fine.

issue with 1 unit of yeast being enough for 4 buckets fixed. it was a logic mistake in recipes's matches method.

behavior changes for consistency and cheat-prevention - any change in fuel tank or yeast slot restarts processing. it was done in simplest way possible. we could have gone more robust and not reset counter when the recipe would remain valid but resetting feels natural - you change contents, you start over. we don't want the barrel too smart.

what was not done: i wanted to cache recipes, but that would make sense to do for all processing blocks, not just one, so another pr. besides, not going through recipes needlessly 20x per second (done in this pr) is much more important than recipe check being more efficient. still it should be done, not because of cpu efficiency, but because of memory efficiency.

added tooltip explanations for when the processing won't start (not enough yeast or bad yeast).