### PR TITLE
fix rice lootTables and rice drops

### DIFF
--- a/src/generated/resources/data/growthcraft/loot_modifiers/grape_seeds_purple_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/grape_seeds_purple_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.2,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/grape_seeds_red_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/grape_seeds_red_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.2,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/grape_seeds_white_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/grape_seeds_white_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.2,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/hops_seeds_white_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/hops_seeds_white_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.2,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/rice_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/rice_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.2,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/thistle_seeds_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/thistle_seeds_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.2,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/yeast_bayanus_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/yeast_bayanus_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.1,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/yeast_brewers_from_grass.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/yeast_brewers_from_grass.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.01,
+      "chance": 0.1,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/yeast_ethereal_from_chorus_flower.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/yeast_ethereal_from_chorus_flower.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.05,
+      "chance": 0.4,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft/loot_modifiers/yeast_lager_from_snow.json
+++ b/src/generated/resources/data/growthcraft/loot_modifiers/yeast_lager_from_snow.json
@@ -2,7 +2,7 @@
   "type": "growthcraft:add_item",
   "conditions": [
     {
-      "chance": 0.02,
+      "chance": 0.2,
       "condition": "minecraft:random_chance"
     },
     {

--- a/src/generated/resources/data/growthcraft_rice/loot_tables/blocks/cultivated_farmland.json
+++ b/src/generated/resources/data/growthcraft_rice/loot_tables/blocks/cultivated_farmland.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dirt"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "growthcraft_rice:blocks/cultivated_farmland"
+}

--- a/src/generated/resources/data/growthcraft_rice/loot_tables/blocks/rice_crop.json
+++ b/src/generated/resources/data/growthcraft_rice/loot_tables/blocks/rice_crop.json
@@ -1,0 +1,69 @@
+{
+  "type": "minecraft:block",
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
+    }
+  ],
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "block": "growthcraft_rice:rice_crop",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "age": "7"
+                  }
+                }
+              ],
+              "name": "growthcraft_rice:rice_stalk"
+            },
+            {
+              "type": "minecraft:item",
+              "name": "growthcraft_rice:rice_grains"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "growthcraft_rice:rice_crop",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 3,
+                "probability": 0.5714286
+              }
+            }
+          ],
+          "name": "growthcraft_rice:rice_grains"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "growthcraft_rice:blocks/rice_crop"
+}

--- a/src/main/java/growthcraft/core/datagen/providers/GrowthcraftCoreGlobalLootModifiersProvider.java
+++ b/src/main/java/growthcraft/core/datagen/providers/GrowthcraftCoreGlobalLootModifiersProvider.java
@@ -41,54 +41,54 @@ public class GrowthcraftCoreGlobalLootModifiersProvider extends GlobalLootModifi
 		add("add_loot_"+ growthcraft.cellar.shared.Reference.LootTable.STRONGHOLD_CHEST_LOOT , loot(name(growthcraft.cellar.shared.Reference.LootTable.STRONGHOLD_CHEST_LOOT), LootTableIdCondition.builder(BuiltInLootTables.STRONGHOLD_CORRIDOR).or(LootTableIdCondition.builder(BuiltInLootTables.STRONGHOLD_CROSSING)).build()));
 		
 		add("grape_seeds_purple_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.2f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftCellarItems.GRAPE_PURPLE_SEED.get().asItem()));
 		
 		add("grape_seeds_red_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.2f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftCellarItems.GRAPE_RED_SEEDS.get().asItem()));
 		
 		add("grape_seeds_white_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.2f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftCellarItems.GRAPE_WHITE_SEEDS.get().asItem()));
 		
 		add("hops_seeds_white_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.2f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftCellarItems.HOPS_SEED.get().asItem()));
 		
 		add("yeast_bayanus_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.1f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftCellarItems.YEAST_BAYANUS.get().asItem()));
 		
 		add("yeast_brewers_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.1f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftCellarItems.YEAST_BREWERS.get().asItem()));
 		
 		add("yeast_ethereal_from_chorus_flower", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.05f).build(),
+				LootItemRandomChanceCondition.randomChance(0.4f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.CHORUS_FLOWER).build()}, 
 				GrowthcraftCellarItems.YEAST_ETHEREAL.get().asItem()));
 		
 		add("yeast_lager_from_snow", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.02f).build(),
+				LootItemRandomChanceCondition.randomChance(0.2f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.SNOW).build()}, 
 				GrowthcraftCellarItems.YEAST_LAGER.get().asItem()));
 		
 //		GC Milk
 		add("thistle_seeds_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.2f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftMilkItems.THISTLE_SEED.get().asItem()));
 		
 //		GC Rice
 		add("rice_from_grass", new AddItemModifier(new LootItemCondition[]{
-				LootItemRandomChanceCondition.randomChance(0.01f).build(),
+				LootItemRandomChanceCondition.randomChance(0.2f).build(),
 				LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.GRASS).build()}, 
 				GrowthcraftRiceItems.RICE_GRAINS.get().asItem()));
 		

--- a/src/main/java/growthcraft/rice/block/RiceCropBlock.java
+++ b/src/main/java/growthcraft/rice/block/RiceCropBlock.java
@@ -47,7 +47,7 @@ public class RiceCropBlock extends CropBlock {
         }
         return InteractionResult.PASS;
     }
-
+    
     @Override
     public boolean canSurvive(BlockState state, LevelReader level, BlockPos pos) {
         return level.getBlockState(pos.below()).is(GrowthcraftRiceBlocks.CULTIVATED_FARMLAND.get());

--- a/src/main/java/growthcraft/rice/datagen/GrowthcraftRiceDataGenerators.java
+++ b/src/main/java/growthcraft/rice/datagen/GrowthcraftRiceDataGenerators.java
@@ -1,6 +1,6 @@
 package growthcraft.rice.datagen;
 
-import growthcraft.rice.datagen.providers.GrowthcraftRiceGlobalLootModifiersProvider;
+import growthcraft.rice.datagen.providers.GrowthcraftRiceLootTableProvider;
 import growthcraft.rice.datagen.providers.GrowthcraftRiceRecipes;
 import growthcraft.rice.shared.Reference;
 import net.minecraft.data.DataGenerator;
@@ -22,6 +22,7 @@ public class GrowthcraftRiceDataGenerators {
 		PackOutput packOutput = generator.getPackOutput();
 		
 		generator.addProvider(event.includeServer(), new GrowthcraftRiceRecipes(packOutput));
+		generator.addProvider(event.includeServer(), new GrowthcraftRiceLootTableProvider(packOutput));
 //		generator.addProvider(event.includeServer(), new GrowthcraftRiceGlobalLootModifiersProvider(packOutput));
 	}
 }

--- a/src/main/java/growthcraft/rice/datagen/providers/GrowthcraftRiceLootTableProvider.java
+++ b/src/main/java/growthcraft/rice/datagen/providers/GrowthcraftRiceLootTableProvider.java
@@ -1,0 +1,22 @@
+package growthcraft.rice.datagen.providers;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.loot.LootTableProvider;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+
+public class GrowthcraftRiceLootTableProvider extends LootTableProvider{
+
+	public GrowthcraftRiceLootTableProvider(PackOutput output) {
+		super(output, Collections.emptySet(), List.of(
+                new LootTableProvider.SubProviderEntry(GrowthcraftRiceLootTables::new, LootContextParamSets.BLOCK)
+        ));
+	}
+
+	@Override
+	public String getName() {
+		return "Growthcraft Rice Loot Tables";
+	}
+}

--- a/src/main/java/growthcraft/rice/datagen/providers/GrowthcraftRiceLootTables.java
+++ b/src/main/java/growthcraft/rice/datagen/providers/GrowthcraftRiceLootTables.java
@@ -1,0 +1,31 @@
+package growthcraft.rice.datagen.providers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import growthcraft.rice.shared.Reference;
+import growthcraft.bamboo.init.GrowthcraftBambooBlocks;
+import growthcraft.rice.init.GrowthcraftRiceBlocks;
+import growthcraft.rice.init.GrowthcraftRiceItems;
+import net.minecraft.advancements.critereon.StatePropertiesPredicate;
+import net.minecraft.data.loot.packs.VanillaBlockLoot;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.CropBlock;
+import net.minecraft.world.level.storage.loot.predicates.LootItemBlockStatePropertyCondition;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public class GrowthcraftRiceLootTables extends VanillaBlockLoot{
+	
+	@Override
+	protected void generate() {
+		add(GrowthcraftRiceBlocks.RICE_CROP.get(), createCropDrops(GrowthcraftRiceBlocks.RICE_CROP.get(), GrowthcraftRiceItems.RICE_STALK.get(), GrowthcraftRiceItems.RICE_GRAINS.get(), LootItemBlockStatePropertyCondition.hasBlockStateProperties(GrowthcraftRiceBlocks.RICE_CROP.get()).setProperties(StatePropertiesPredicate.Builder.properties().hasProperty(CropBlock.AGE, 7))));	
+		dropOther(GrowthcraftRiceBlocks.CULTIVATED_FARMLAND.get(), Blocks.DIRT);
+	}
+	
+    @Override
+    protected Iterable<Block> getKnownBlocks() {
+    	return List.of(GrowthcraftRiceBlocks.RICE_CROP.get(), GrowthcraftRiceBlocks.CULTIVATED_FARMLAND.get());
+    }
+}


### PR DESCRIPTION
adapted the chance for all items that drop from grass.
added lootTable datagen for rice blocks. the old json for the rice_crop_block was the cause of the multi drop when destroying the crop block. 