### PR TITLE
Disabled kumis recipe

### DIFF
--- a/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
+++ b/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
@@ -97,6 +97,7 @@ public class GrowthcraftCellar {
 
     private void setup(final FMLCommonSetupEvent event) {
         GrowthcraftCellarMessages.register();
+        GrowthcraftCellarItems.registerCompostables();
     }
 
     public void buildCreativeTabContents(BuildCreativeModeTabContentsEvent event) {

--- a/src/main/java/growthcraft/cellar/init/GrowthcraftCellarItems.java
+++ b/src/main/java/growthcraft/cellar/init/GrowthcraftCellarItems.java
@@ -8,12 +8,14 @@ import growthcraft.lib.item.GrowthcraftFoodItem;
 import growthcraft.lib.item.GrowthcraftItem;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.ComposterBlock;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class GrowthcraftCellarItems {
 
@@ -155,20 +157,31 @@ public class GrowthcraftCellarItems {
     );
 
     public static void registerCompostables() {
-        float f = 0.3F;
+        float f0 = 0.3F;
         float f1 = 0.5F;
         float f2 = 0.65F;
         float f3 = 0.85F;
         float f4 = 1.0F;
 
-        // ComposterBlock.COMPOSTABLES.put(GrowthcraftRiceItems.RICE.get(), f2);
-
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.GRAPE_WHITE_SEEDS.get(), 0.1f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.GRAPE_RED_SEEDS.get(), 0.1f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.GRAPE_PURPLE_SEED.get(), 0.1f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.GRAPE_WHITE.get(), 0.6f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.GRAPE_RED.get(), 0.6f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.GRAPE_PURPLE.get(), 0.6f);
+        for (RegistryObject<? extends Item> grain : GRAINS) {
+            ComposterBlock.COMPOSTABLES.put(grain.get(), 0.2f);
+        }
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.GRAIN.get(), 0.3f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.HOPS.get(), 0.3f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.HOPS_SEED.get(), 0.1f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.YEAST_LAGER.get(), 0.5f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.YEAST_BAYANUS.get(), 0.5f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftCellarItems.YEAST_BREWERS.get(), 0.5f);
     }
 
     public static boolean excludeItemRegistry(ResourceLocation registryName) {
-        ArrayList<String> excludeItems = new ArrayList<>();
-        //excludeItems.add(Reference.MODID + ":" + Reference.UnlocalizedName.APPLE_TREE_FRUIT);
-        return excludeItems.contains(registryName.toString());
+        return false;
     }
 
     private GrowthcraftCellarItems() {

--- a/src/main/java/growthcraft/milk/init/GrowthcraftMilkBlocks.java
+++ b/src/main/java/growthcraft/milk/init/GrowthcraftMilkBlocks.java
@@ -239,10 +239,10 @@ public class GrowthcraftMilkBlocks {
 
     /////////// shop signs ////////////
 
-    private static final RegistryObject<Block> SHOP_SIGN_1_OAK = registerBlock("hanging_sign_1_oak", () -> makeSign(Blocks.OAK_HANGING_SIGN));
-    private static final RegistryObject<Block> SHOP_SIGN_2_OAK = registerBlock("hanging_sign_2_oak", () -> makeSign(Blocks.OAK_WALL_HANGING_SIGN));
-    private static final RegistryObject<Block> SHOP_SIGN_1_SPRUCE = registerBlock("hanging_sign_1_spruce", () -> makeSign(Blocks.SPRUCE_HANGING_SIGN));
-    private static final RegistryObject<Block> SHOP_SIGN_2_SPRUCE = registerBlock("hanging_sign_2_spruce", () -> makeSign(Blocks.SPRUCE_WALL_HANGING_SIGN));
+    private static final RegistryObject<Block> SHOP_SIGN_1_OAK = registerBlock("hanging_sign_1_oak", () -> makeSign(Blocks.OAK_HANGING_SIGN), true);
+    private static final RegistryObject<Block> SHOP_SIGN_2_OAK = registerBlock("hanging_sign_2_oak", () -> makeSign(Blocks.OAK_WALL_HANGING_SIGN), true);
+    private static final RegistryObject<Block> SHOP_SIGN_1_SPRUCE = registerBlock("hanging_sign_1_spruce", () -> makeSign(Blocks.SPRUCE_HANGING_SIGN), true);
+    private static final RegistryObject<Block> SHOP_SIGN_2_SPRUCE = registerBlock("hanging_sign_2_spruce", () -> makeSign(Blocks.SPRUCE_WALL_HANGING_SIGN), true);
 
     ///////////////////////////////////
 

--- a/src/main/java/growthcraft/milk/init/GrowthcraftMilkItems.java
+++ b/src/main/java/growthcraft/milk/init/GrowthcraftMilkItems.java
@@ -246,9 +246,8 @@ public class GrowthcraftMilkItems {
         float f2 = 0.65F;
         float f3 = 0.85F;
         float f4 = 1.0F;
-
-        ComposterBlock.COMPOSTABLES.put(GrowthcraftMilkItems.THISTLE_SEED.get(), f2);
-
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftMilkItems.THISTLE_SEED.get(), f);
+        ComposterBlock.COMPOSTABLES.put(GrowthcraftMilkItems.THISTLE.get(), f1);
     }
 
     public static boolean excludeItemRegistry(ResourceLocation registryName) {

--- a/src/main/java/growthcraft/rice/GrowthcraftRice.java
+++ b/src/main/java/growthcraft/rice/GrowthcraftRice.java
@@ -48,7 +48,7 @@ public class GrowthcraftRice {
     }
 
     private void setup(final FMLCommonSetupEvent event) {
-        // Do nothing
+        GrowthcraftRiceItems.registerCompostables();
     }
 
     public void buildCreativeTabContents(BuildCreativeModeTabContentsEvent event) {

--- a/src/main/resources/data/growthcraft_cellar/recipes/fermentation_barrel_kumis.json
+++ b/src/main/resources/data/growthcraft_cellar/recipes/fermentation_barrel_kumis.json
@@ -1,5 +1,10 @@
 {
   "type": "growthcraft_cellar:fermentation_barrel_recipe",
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ],
   "processing_time": 1200,
   "ingredient_item": {
     "item": "growthcraft_cellar:yeast_brewers",


### PR DESCRIPTION
Viewing brewer's yeast usages in JEI crashes the game (EMI handles it better).
I have disabled the offending recipe in this PR as a temporary measure.

I think removing this feature (and maybe reimplementing it later again) isn't a big waste.