### PR TITLE
Cheese Wheel Performance Improvement - onTick to randomTick

### DIFF
--- a/src/main/java/growthcraft/milk/block/BaseCheeseWheel.java
+++ b/src/main/java/growthcraft/milk/block/BaseCheeseWheel.java
@@ -77,6 +77,8 @@ public class BaseCheeseWheel extends BaseEntityBlock {
         return GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get().create(blockPos, blockState);
     }
     
+    //randomTick is called once every ~1min. there is no guarantee that its exactly every 60sec.
+    //the value of CheeseWheelBlockEntity#maxTick should reflect this. default: 60
     @Override
 	public void randomTick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
     	CheeseWheelBlockEntity blockEntity = (CheeseWheelBlockEntity) pLevel.getBlockEntity(pPos);

--- a/src/main/java/growthcraft/milk/block/BaseCheeseWheel.java
+++ b/src/main/java/growthcraft/milk/block/BaseCheeseWheel.java
@@ -1,5 +1,12 @@
 package growthcraft.milk.block;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.Nullable;
+
 import growthcraft.apiary.init.GrowthcraftApiaryItems;
 import growthcraft.milk.block.entity.CheeseWheelBlockEntity;
 import growthcraft.milk.init.GrowthcraftMilkBlockEntities;
@@ -7,6 +14,8 @@ import growthcraft.milk.init.GrowthcraftMilkBlocks;
 import growthcraft.milk.init.GrowthcraftMilkItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -15,10 +24,13 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityTicker;
-import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -29,12 +41,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.registries.RegistryObject;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 public class BaseCheeseWheel extends BaseEntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
@@ -70,15 +76,13 @@ public class BaseCheeseWheel extends BaseEntityBlock {
     public BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
         return GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get().create(blockPos, blockState);
     }
-
-    @Nullable
+    
     @Override
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState blockState, BlockEntityType<T> blockEntityType) {
-        return createTickerHelper(
-                blockEntityType,
-                GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get(),
-                (worldLevel, pos, state, blockEntity) -> (blockEntity).tick()
-        );    }
+	public void randomTick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
+    	CheeseWheelBlockEntity blockEntity = (CheeseWheelBlockEntity) pLevel.getBlockEntity(pPos);
+    	blockEntity.ageCheese(pLevel, pPos, pState, blockEntity);
+    }
+    
 
     @Override
     public RenderShape getRenderShape(BlockState p_60550_) {

--- a/src/main/java/growthcraft/milk/block/CheeseWheelAgeableBlock.java
+++ b/src/main/java/growthcraft/milk/block/CheeseWheelAgeableBlock.java
@@ -1,7 +1,14 @@
 package growthcraft.milk.block;
 
+import net.minecraft.world.level.block.state.BlockState;
+
 public class CheeseWheelAgeableBlock extends BaseCheeseWheel {
     public CheeseWheelAgeableBlock(Cheese variant) {
         super(variant);
     }
+    
+	@Override
+	public boolean isRandomlyTicking(BlockState pState) {
+		return true;
+	}
 }

--- a/src/main/java/growthcraft/milk/block/CheeseWheelBlock.java
+++ b/src/main/java/growthcraft/milk/block/CheeseWheelBlock.java
@@ -8,8 +8,6 @@ import growthcraft.core.init.GrowthcraftTags;
 import growthcraft.milk.block.entity.CheeseWheelBlockEntity;
 import growthcraft.milk.init.GrowthcraftMilkBlockEntities;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -34,6 +32,7 @@ import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+
 @Deprecated
 public class CheeseWheelBlock extends BaseEntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
@@ -68,22 +67,6 @@ public class CheeseWheelBlock extends BaseEntityBlock {
     @Override
     public BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
         return GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get().create(blockPos, blockState);
-    }
-
-//    @Nullable
-//    @Override
-//    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState blockState, BlockEntityType<T> blockEntityType) {
-//        return createTickerHelper(
-//                blockEntityType,
-//                GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get(),
-//                (worldLevel, pos, state, blockEntity) -> (blockEntity).tick()
-//        );    }
-    
-    @Override
-	public void randomTick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
-    	CheeseWheelBlockEntity blockEntity = (CheeseWheelBlockEntity) pLevel.getBlockEntity(pPos);
-    	System.out.println("el random tick");
-    	blockEntity.ageCheese(pLevel, pPos, pState, blockEntity);
     }
 
     @Override

--- a/src/main/java/growthcraft/milk/block/CheeseWheelBlock.java
+++ b/src/main/java/growthcraft/milk/block/CheeseWheelBlock.java
@@ -1,10 +1,15 @@
 package growthcraft.milk.block;
 
+import java.awt.Color;
+
+import org.jetbrains.annotations.Nullable;
+
 import growthcraft.core.init.GrowthcraftTags;
 import growthcraft.milk.block.entity.CheeseWheelBlockEntity;
 import growthcraft.milk.init.GrowthcraftMilkBlockEntities;
-import growthcraft.rice.init.GrowthcraftRiceTags;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -12,10 +17,13 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityTicker;
-import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -26,10 +34,6 @@ import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import org.jetbrains.annotations.Nullable;
-
-import java.awt.*;
-
 @Deprecated
 public class CheeseWheelBlock extends BaseEntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
@@ -66,14 +70,21 @@ public class CheeseWheelBlock extends BaseEntityBlock {
         return GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get().create(blockPos, blockState);
     }
 
-    @Nullable
+//    @Nullable
+//    @Override
+//    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState blockState, BlockEntityType<T> blockEntityType) {
+//        return createTickerHelper(
+//                blockEntityType,
+//                GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get(),
+//                (worldLevel, pos, state, blockEntity) -> (blockEntity).tick()
+//        );    }
+    
     @Override
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState blockState, BlockEntityType<T> blockEntityType) {
-        return createTickerHelper(
-                blockEntityType,
-                GrowthcraftMilkBlockEntities.CHEESE_WHEEL_BLOCK_ENTITY.get(),
-                (worldLevel, pos, state, blockEntity) -> (blockEntity).tick()
-        );    }
+	public void randomTick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
+    	CheeseWheelBlockEntity blockEntity = (CheeseWheelBlockEntity) pLevel.getBlockEntity(pPos);
+    	System.out.println("el random tick");
+    	blockEntity.ageCheese(pLevel, pPos, pState, blockEntity);
+    }
 
     @Override
     public RenderShape getRenderShape(BlockState p_60550_) {

--- a/src/main/java/growthcraft/milk/block/entity/CheeseWheelBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/CheeseWheelBlockEntity.java
@@ -1,5 +1,14 @@
 package growthcraft.milk.block.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import growthcraft.milk.GrowthcraftMilk;
 import growthcraft.milk.block.BaseCheeseWheel;
 import growthcraft.milk.block.CheeseWheelAgeableBlock;
@@ -17,18 +26,10 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
-public class CheeseWheelBlockEntity extends BlockEntity implements BlockEntityTicker<CheeseWheelBlockEntity> {
+public class CheeseWheelBlockEntity extends BlockEntity {
     private boolean aged;
     private int sliceCountTop;
     private int sliceCountBottom;
@@ -46,7 +47,7 @@ public class CheeseWheelBlockEntity extends BlockEntity implements BlockEntityTi
     public CheeseWheelBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
         super(blockEntityType, blockPos, blockState);
         this.tickClock = 0;
-        this.tickMax = 24000 * 3;
+        this.tickMax = 60;
 
         // TODO: Implement aging process
         this.aged = true;
@@ -54,15 +55,7 @@ public class CheeseWheelBlockEntity extends BlockEntity implements BlockEntityTi
         this.sliceCountTop = 0;
     }
 
-    public void tick() {
-        if (this.getLevel() != null) {
-            this.tick(this.getLevel(), this.getBlockPos(), this.getBlockState(), this);
-        }
-    }
-
-    @Override
-    @ParametersAreNonnullByDefault
-    public void tick(Level level, BlockPos blockPos, BlockState blockState, CheeseWheelBlockEntity blockEntity) {
+    public void ageCheese(Level level, BlockPos blockPos, BlockState blockState, CheeseWheelBlockEntity blockEntity) {
         if (level.isClientSide()) {
             return;
         }
@@ -85,7 +78,7 @@ public class CheeseWheelBlockEntity extends BlockEntity implements BlockEntityTi
             } else {
                 // This is probably broken cheese that was aged before 9.0.6
                 // lets start the aging process over again, and this time do it properly
-                this.tickMax = 3 * 24000;
+                this.tickMax = 60;
                 this.tickClock = 0;
             }
         }

--- a/src/main/java/growthcraft/milk/block/entity/CheeseWheelBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/CheeseWheelBlockEntity.java
@@ -14,6 +14,7 @@ import growthcraft.milk.block.BaseCheeseWheel;
 import growthcraft.milk.block.CheeseWheelAgeableBlock;
 import growthcraft.milk.block.CheeseWheelBlock;
 import growthcraft.milk.init.GrowthcraftMilkBlockEntities;
+import growthcraft.milk.init.config.GrowthcraftMilkConfig;
 import growthcraft.milk.recipe.CheesePressRecipe;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -35,8 +36,7 @@ public class CheeseWheelBlockEntity extends BlockEntity {
     private int sliceCountBottom;
 
     private int tickClock;
-    //TODO: Make max aging for CheeseWheel come from a config
-    private int tickMax;
+    private int tickMax = GrowthcraftMilkConfig.getCheeseAgeTickTime();
 
     private Component customName;
 
@@ -47,9 +47,6 @@ public class CheeseWheelBlockEntity extends BlockEntity {
     public CheeseWheelBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
         super(blockEntityType, blockPos, blockState);
         this.tickClock = 0;
-        this.tickMax = 60;
-
-        // TODO: Implement aging process
         this.aged = true;
         this.sliceCountBottom = 4;
         this.sliceCountTop = 0;
@@ -78,7 +75,7 @@ public class CheeseWheelBlockEntity extends BlockEntity {
             } else {
                 // This is probably broken cheese that was aged before 9.0.6
                 // lets start the aging process over again, and this time do it properly
-                this.tickMax = 60;
+                this.tickMax = GrowthcraftMilkConfig.getCheeseAgeTickTime();
                 this.tickClock = 0;
             }
         }

--- a/src/main/java/growthcraft/milk/init/config/GrowthcraftMilkConfig.java
+++ b/src/main/java/growthcraft/milk/init/config/GrowthcraftMilkConfig.java
@@ -1,11 +1,12 @@
 package growthcraft.milk.init.config;
 
+import java.io.File;
+
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.core.io.WritingMode;
+
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.loading.FMLPaths;
-
-import java.io.File;
 
 public class GrowthcraftMilkConfig {
 
@@ -32,6 +33,7 @@ public class GrowthcraftMilkConfig {
     private static ForgeConfigSpec.BooleanValue pancheonGuiEnabled;
     private static ForgeConfigSpec.BooleanValue stomachLootEnabled;
     private static ForgeConfigSpec.IntValue stomachLootChance;
+    private static ForgeConfigSpec.IntValue cheeseAgeTime;
 
     private static ForgeConfigSpec.BooleanValue cheeseDebugEnabled;
 
@@ -93,6 +95,10 @@ public class GrowthcraftMilkConfig {
         cheeseDebugEnabled = specBuilder
                 .comment("Set to true to add additional logging to debug the cheese wheel and curds blocks.")
                 .define(String.format("%s.%s", CATEGORY_CHEESE, "debugEnabled"), false);
+        
+        cheeseAgeTime = specBuilder
+		        .comment("Amount of random ticks it takes, for a cheese wheel to age. One random tick happens every ~1min.")
+		        .defineInRange(String.format("%s.%s", CATEGORY_CHEESE, "cheeseAgeTime"), 60, 0, 240);
 
     }
 
@@ -180,6 +186,15 @@ public class GrowthcraftMilkConfig {
      * exception: allow beverages even if the module is disabled
      */
     public static boolean getFeatureEnabledBeverages() { return featureEnabledBeverages.get(); }
+    
+    /**
+     * Retrieves the number of random ticks it takes, for a cheese wheel to age. 
+     *
+     * @return the amount of random ticks as an integer value, ranging from 0 to 240.
+     */
+    public static int getCheeseAgeTickTime() {
+        return cheeseAgeTime.get();
+    }
 
     /**
      * is the whole module disabled


### PR DESCRIPTION
this addresses the issue raised in #159, that chesse wheels are ticking tile entities. 

they now use randomTick, and only a AgeableCheese is then actually ticking. The amount of ticks needed has been reduced to 60 (this should still be ~ 60min)

also i noticed that the CheeseWheelBlock class is not used anywhere, so i marked it as Deprecated, because i am not sure if there is any use (or planned use) for it or not. 

i kept the rest of the chesse wheels as they are, so we might revist them and make further improvements later. 